### PR TITLE
[FIX] OG invader black image

### DIFF
--- a/app/api/get-thumbnail/route.ts
+++ b/app/api/get-thumbnail/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+import sharp from "sharp";
+
+export const runtime = "nodejs";
+export async function GET(request: NextRequest): Promise<Response> {
+  const param = request.nextUrl.searchParams.get("url");
+  if (!param) return Response.json({ error: true, data: null });
+  try {
+    const url = new URL(param);
+    const res = await fetch(url);
+    const buffer = await res.arrayBuffer();
+    const thumbnailBuffer = await sharp(buffer).toFormat("png").toBuffer();
+    const image = thumbnailBuffer.toString("base64");
+    return Response.json(image);
+  } catch (err) {
+    console.error(err);
+    return Response.json({ error: true, data: null });
+  }
+}

--- a/app/api/map/invaders/[invaderName]/OG/route.tsx
+++ b/app/api/map/invaders/[invaderName]/OG/route.tsx
@@ -28,11 +28,21 @@ export async function GET(
   const fontData = await fontResponse.arrayBuffer();
   const searchParams = new URLSearchParams(gmapUrlParams);
   const invaderName = params.params.invaderName;
+
   const [invader] = await db
     .select()
     .from(invaders)
     .where(eq(invaders.name, invaderName));
 
+  const res = await fetch(
+    `${request.nextUrl.origin}/api/get-thumbnail?url=${invader.thumbnail}`,
+    {
+      next: {
+        tags: [`${invader.name}:og`],
+      },
+    }
+  );
+  const b64ImageUrl = await res.json();
   if (invader.location) {
     searchParams.set(
       "center",
@@ -75,7 +85,7 @@ export async function GET(
         >
           {invader && (
             <img
-              src={invader.thumbnail}
+              src={`data:image/png;base64,${b64ImageUrl}`}
               width={256}
               height={256}
               style={{


### PR DESCRIPTION
as we were previously using PNGs in our OG route handler, using them with `@vercel/og` (`satori`) on edge network was fine.
But now we're using AVIF, which is not supported by `satori`, we have to convert it to png using `sharp`, but, `sharp` is not supported on edge which sucks a lot (due to usage of `spawnSync` from `node:child-process` which is not allowed on edge).
So the best workaround i found was to create a nodejs api route that takes the avif url as query param and return the base64 of it in png format (out of `sharp`) because we cant use fileReader API on edge to convert blob to data URI. Then we use it as data URI in our `@vercel/og` JSX template, which works fine but send a lot of data.

TLDR: a lot of crappy stuff here